### PR TITLE
Respond with picker best on low time

### DIFF
--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     search::{
         Depth, MAX_DEPTH, Searcher,
         game_history::GameHistory,
+        picker::MovePicker,
         score_table::{DEFAULT_TABLE_SIZE_MB, ScoreTable},
         status::{SearchStatus, SearchStatusValue},
         window::Window,
@@ -108,7 +109,10 @@ impl Engine {
 
             status.set(SearchStatusValue::Stopped);
 
-            if let Some(best_move) = pv.first() {
+            if let Some(best_move) = pv.first().cloned().or_else(|| {
+                let mut picker = MovePicker::new(&position, false, None, [None, None]);
+                picker.next().map(|mov| mov.to_string())
+            }) {
                 if let Some(ponder_move) = pv.get(1) {
                     println!("bestmove {} ponder {}", best_move, ponder_move);
                 } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fallback so the engine always outputs a valid best move (and optional ponder) when the principal variation is empty, by selecting an alternative legal move. This prevents blank or `(none)` bestmove lines and improves robustness in edge-case evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->